### PR TITLE
fix(forms): validate and mark fields dirty when autofilled via TestCodes

### DIFF
--- a/frontend/app/components/billpay/TV/Tv.tsx
+++ b/frontend/app/components/billpay/TV/Tv.tsx
@@ -101,7 +101,12 @@ export default function TVTab() {
     <div className="w-full max-w-lg bg-white dark:bg-gray-900">
       <TestCodes
         testCodes={TV_TEST_CODES}
-        onSelect={(number) => form.setValue("smartCardNumber", number)}
+        onSelect={(number) =>
+          form.setValue("smartCardNumber", number, {
+            shouldValidate: true,
+            shouldDirty: true,
+          })
+        }
       />
 
       <Form {...form}>

--- a/frontend/app/components/billpay/airtime/Airtime.tsx
+++ b/frontend/app/components/billpay/airtime/Airtime.tsx
@@ -63,7 +63,12 @@ export default function Airtime() {
     <div className="w-full max-w-lg bg-white dark:bg-gray-900">
       <TestCodes
         testCodes={AIRTIME_TEST_NUMBERS}
-        onSelect={(number) => form.setValue("phone", number)}
+        onSelect={(number) =>
+          form.setValue("phone", number, {
+            shouldValidate: true,
+            shouldDirty: true,
+          })
+        }
       />
 
       <Form {...form}>

--- a/frontend/app/components/billpay/data/Data.tsx
+++ b/frontend/app/components/billpay/data/Data.tsx
@@ -66,7 +66,12 @@ export default function DataTab() {
     <div className="w-full max-w-lg bg-white dark:bg-gray-900">
       <TestCodes
         testCodes={DATA_TEST_NUMBERS}
-        onSelect={(number) => form.setValue("phone", number)}
+        onSelect={(number) =>
+          form.setValue("phone", number, {
+            shouldValidate: true,
+            shouldDirty: true,
+          })
+        }
       />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">

--- a/frontend/app/components/billpay/electricity/Electricity.tsx
+++ b/frontend/app/components/billpay/electricity/Electricity.tsx
@@ -114,7 +114,12 @@ export default function Electricity() {
     <div className="w-full max-w-lg bg-white dark:bg-gray-900">
       <TestCodes
         testCodes={ELECTRICITY_TEST_CODES}
-        onSelect={(number) => form.setValue("meterNumber", number)}
+        onSelect={(number) =>
+          form.setValue("meterNumber", number, {
+            shouldValidate: true,
+            shouldDirty: true,
+          })
+        }
       />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">


### PR DESCRIPTION
### **Fix: Ensure form fields validate and mark as dirty when autofilled via TestCodes**

This PR updates the `onSelect` handlers across multiple BillPay components to correctly trigger validation and dirty-state updates when autofilling form values from **TestCodes**.

Previously, selecting a test code would populate the form field but **would not**:

* run validation
* mark the field as dirty

This caused issues where the UI didn’t reflect the expected validation state, and forms could fail submission or skip validation steps.

### ✅ What’s Changed

Across these components:

* `TV`
* `Airtime`
* `Data`
* `Electricity`

`form.setValue` now includes options:

```ts
{
  shouldValidate: true,
  shouldDirty: true,
}
```

### 🛠 Updated Example

```ts
form.setValue("phone", number, {
  shouldValidate: true,
  shouldDirty: true,
});
```

### 🎯 Impact

* Ensures correct real-time validation when autofilling test data
* Improves UX by reflecting the proper form state
* Prevents unexpected submission errors due to unvalidated fields
