### PR TITLE
Add payment reconciliation logic

### DIFF
--- a/backend/src/modules/payment/payment.consumer.ts
+++ b/backend/src/modules/payment/payment.consumer.ts
@@ -1,0 +1,197 @@
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
+import { Job } from 'bullmq';
+import { JOB_NAMES, QUEUE_NAMES } from 'src/common/types/bullmq';
+import { Logger } from '@nestjs/common';
+import { PaymentService } from './payment.service';
+import { InterSwitchService } from 'src/integration/interswitch/interswitch.service';
+import { VTPassService } from 'src/integration/vtpass/vtpass.service';
+import { AttemptStatus, PaymentStatus } from '@prisma/client';
+
+@Processor(QUEUE_NAMES.PAYMENT)
+export class PaymentConsumer extends WorkerHost {
+  private readonly logger = new Logger(PaymentConsumer.name);
+
+  constructor(
+    private readonly paymentService: PaymentService,
+    private readonly interswitchService: InterSwitchService,
+    private readonly vtpassService: VTPassService,
+  ) {
+    super();
+  }
+
+  @OnWorkerEvent('active')
+  onActive(job: Job) {
+    this.logger.log(`Processing job ${job.id} of type ${job.name}`);
+  }
+
+  public async process(job: Job) {
+    switch (job.name) {
+      case JOB_NAMES.PAYMENT_RECONCILATION: {
+        await this.reconcilePayment(job.data);
+        break;
+      }
+      default:
+        this.logger.warn(`Unknown job name: ${job.name}`);
+    }
+  }
+
+  /**
+   * Reconciles a pending payment by checking its status with the provider
+   * @param data - Contains paymentRef and optional attemptId
+   */
+  private async reconcilePayment(data: {
+    paymentRef: string;
+    attemptId?: string;
+  }) {
+    const { paymentRef, attemptId } = data;
+    this.logger.log(`Reconciling payment: ${paymentRef}`);
+
+    try {
+      // Fetch the payment record
+      const payment =
+        await this.paymentService.findPaymentByReference(paymentRef);
+
+      if (!payment) {
+        this.logger.warn(`Payment not found: ${paymentRef}`);
+        return;
+      }
+
+      // Skip if payment is already in a final state
+      if (
+        payment.status === PaymentStatus.SUCCESS ||
+        payment.status === PaymentStatus.FAILED
+      ) {
+        this.logger.log(
+          `Payment ${paymentRef} already in final state: ${payment.status}`,
+        );
+        return;
+      }
+
+      // Determine which provider to query based on the last attempt or payment metadata
+      // For now, we'll try both providers (Interswitch first, then VTPass)
+      let reconciled = false;
+
+      // Try Interswitch
+      try {
+        const interswitchResult =
+          await this.interswitchService.confirmTransaction(paymentRef);
+
+        if (interswitchResult.ResponseCodeGrouping === 'SUCCESSFUL') {
+          await this.updatePaymentSuccess(
+            payment.id,
+            attemptId,
+            interswitchResult,
+          );
+          this.logger.log(
+            `✅ Payment ${paymentRef} reconciled successfully via Interswitch`,
+          );
+          reconciled = true;
+        } else if (interswitchResult.ResponseCodeGrouping === 'FAILED') {
+          await this.updatePaymentFailed(
+            payment.id,
+            attemptId,
+            interswitchResult,
+          );
+          this.logger.log(
+            `❌ Payment ${paymentRef} marked as failed via Interswitch`,
+          );
+          reconciled = true;
+        }
+      } catch (interswitchError) {
+        this.logger.debug(
+          `Interswitch reconciliation failed for ${paymentRef}`,
+          interswitchError?.response?.data ?? interswitchError?.message,
+        );
+      }
+
+      // If Interswitch didn't reconcile, try VTPass
+      if (!reconciled) {
+        try {
+          const vtpassResult =
+            await this.vtpassService.getTransaction(paymentRef);
+
+          if (vtpassResult.status === 'delivered') {
+            await this.updatePaymentSuccess(
+              payment.id,
+              attemptId,
+              vtpassResult,
+            );
+            this.logger.log(
+              `✅ Payment ${paymentRef} reconciled successfully via VTPass`,
+            );
+            reconciled = true;
+          } else if (vtpassResult.status === 'failed') {
+            await this.updatePaymentFailed(payment.id, attemptId, vtpassResult);
+            this.logger.log(
+              `❌ Payment ${paymentRef} marked as failed via VTPass`,
+            );
+            reconciled = true;
+          }
+        } catch (vtpassError) {
+          this.logger.debug(
+            `VTPass reconciliation failed for ${paymentRef}`,
+            vtpassError?.response?.data ?? vtpassError?.message,
+          );
+        }
+      }
+
+      if (!reconciled) {
+        this.logger.warn(
+          `Payment ${paymentRef} still pending after reconciliation attempt`,
+        );
+        // The job will be retried based on the queue configuration
+        throw new Error(
+          `Unable to reconcile payment ${paymentRef} - still pending`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error reconciling payment ${paymentRef}`,
+        error?.stack ?? error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Updates payment and attempt to SUCCESS status
+   */
+  private async updatePaymentSuccess(
+    paymentId: string,
+    attemptId: string | undefined,
+    providerResponse: any,
+  ) {
+    await this.paymentService.updatePayment(paymentId, {
+      status: PaymentStatus.SUCCESS,
+      completedAt: new Date(),
+    });
+
+    if (attemptId) {
+      await this.paymentService.updatePaymentAttempt(attemptId, {
+        status: AttemptStatus.SUCCESS,
+        responsePayload: JSON.stringify(providerResponse),
+      });
+    }
+  }
+
+  /**
+   * Updates payment and attempt to FAILED status
+   */
+  private async updatePaymentFailed(
+    paymentId: string,
+    attemptId: string | undefined,
+    providerResponse: any,
+  ) {
+    await this.paymentService.updatePayment(paymentId, {
+      status: PaymentStatus.FAILED,
+      lastError: JSON.stringify(providerResponse),
+    });
+
+    if (attemptId) {
+      await this.paymentService.updatePaymentAttempt(attemptId, {
+        status: AttemptStatus.FAILED,
+        responsePayload: JSON.stringify(providerResponse),
+      });
+    }
+  }
+}

--- a/backend/src/modules/payment/payment.module.ts
+++ b/backend/src/modules/payment/payment.module.ts
@@ -4,10 +4,18 @@ import { PaymentRepository } from './payment.repository';
 import { PrismaService } from 'src/prisma.service';
 import { BillsModule } from '../bills/bills.module';
 import { PaymentController } from './payment.controller';
+import { PaymentConsumer } from './payment.consumer';
+import { InterSwitchModule } from 'src/integration/interswitch/interswitch.module';
+import { VTPassModule } from 'src/integration/vtpass/vtpass.module';
 
 @Module({
-  imports: [forwardRef(() => BillsModule)],
-  providers: [PaymentService, PaymentRepository, PrismaService],
+  imports: [forwardRef(() => BillsModule), InterSwitchModule, VTPassModule],
+  providers: [
+    PaymentService,
+    PaymentRepository,
+    PrismaService,
+    PaymentConsumer,
+  ],
   controllers: [PaymentController],
   exports: [PaymentService],
 })

--- a/backend/src/modules/payment/payment.repository.ts
+++ b/backend/src/modules/payment/payment.repository.ts
@@ -137,7 +137,7 @@ export class PaymentRepository {
     id: string,
     data: Pick<
       Prisma.PaymentAttemptUncheckedCreateInput,
-      'status' | 'requestPayload' | 'errorMessage'
+      'status' | 'responsePayload' | 'errorMessage'
     >,
   ) {
     return this.prisma.paymentAttempt.update({

--- a/backend/src/modules/payment/payment.repository.ts
+++ b/backend/src/modules/payment/payment.repository.ts
@@ -148,4 +148,13 @@ export class PaymentRepository {
       },
     });
   }
+
+  public async findPaymentAttemptById(id: string) {
+    return this.prisma.paymentAttempt.findUnique({
+      where: { id },
+      include: {
+        provider: true,
+      },
+    });
+  }
 }

--- a/backend/src/modules/payment/payment.service.ts
+++ b/backend/src/modules/payment/payment.service.ts
@@ -97,4 +97,8 @@ export class PaymentService {
   ) {
     return this.paymentRepo.findPayment(data, tx);
   }
+
+  public async findPaymentAttemptById(id: string) {
+    return this.paymentRepo.findPaymentAttemptById(id);
+  }
 }

--- a/backend/src/modules/queue/queue.service.ts
+++ b/backend/src/modules/queue/queue.service.ts
@@ -22,7 +22,7 @@ export class QueueService {
     attemptId,
   }: {
     paymentRef: string;
-    attemptId?: string;
+    attemptId: string;
   }) {
     await this.paymentQueue.add(
       JOB_NAMES.PAYMENT_RECONCILATION,


### PR DESCRIPTION
This PR adds the initial reconciliation wiring for the payments flow. It prepares the payment module to receive and persist provider responses, and introduces a consumer used to process async reconciliation jobs. The primary goal is to enable reliable reconciliation between our internal payment attempts and external provider outcomes (InterSwitch, VTPass).

### **What changed**

* **PaymentModule**

  * Registered `InterSwitchModule` and `VTPassModule` so provider-specific integrations are available to the payment flow.
  * Added `PaymentConsumer` to `providers` — this consumer will process reconciliation jobs (e.g., poll provider status, handle callbacks, or process queue messages that reconcile attempts).

* **PaymentRepository**

  * `updatePaymentAttempt` now accepts and stores **`responsePayload`** (instead of `requestPayload`) so raw provider responses are persisted. This is required to:

    * Compare provider responses to the original attempt (reconciliation).
    * Log provider data for audits and debugging.
    * Drive state transitions (success / failed / pending) during reconciliation.
